### PR TITLE
Feature 5/add maze to graph

### DIFF
--- a/src/maze.ts
+++ b/src/maze.ts
@@ -20,6 +20,14 @@ export type Maze = {
 
 };
 
+export function is_path(maze_block: MazeBlock): maze_block is Free {
+    return maze_block;
+}
+
+export function is_wall(maze_block: MazeBlock): maze_block is Wall {
+    return !maze_block;
+}
+
 export function new_maze(size: number, default_block: MazeBlock = free): Maze {
     const matrix = Array<Array<MazeBlock>>(size);
     matrix.fill(Array<MazeBlock>(size));
@@ -122,7 +130,7 @@ export function maze_to_listgraph(maze: Maze): ListGraph {
     function has_edge(row: number, col: number): boolean {
         return 0 <= row && row < maze.matrix.length
             ? 0 <= col && col < maze.matrix[row].length
-                ? maze.matrix[row][col] !== wall
+                ? is_path(maze.matrix[row][col])
                     ? true
                     : false
                 : false
@@ -131,7 +139,7 @@ export function maze_to_listgraph(maze: Maze): ListGraph {
     let edges: EdgeList = list();
     maze.matrix.forEach((maze_row, row_index) => {
         maze_row.forEach((maze_block, col_index) => {
-            if (maze_block !== wall) {
+            if (is_path(maze_block)) {
                 const source = flatten_index(row_index, col_index, maze);
                 for (let x_offset = -1; x_offset < 1; x_offset += 2) {
                     if (has_edge(row_index, col_index + x_offset)) {

--- a/src/maze.ts
+++ b/src/maze.ts
@@ -1,6 +1,11 @@
+import { ListGraph, lg_from_edges, EdgeList } from "./graphs";
+import { list, pair } from "./list";
+
 export type Free = true;
+export const free = true;
 
 export type Wall = false;
+export const wall = false;
 
 export type MazeBlock = Wall | Free;
 
@@ -14,3 +19,152 @@ export type Maze = {
     matrix: Array<Array<MazeBlock>>;
 
 };
+
+export function new_maze(size: number, default_block: MazeBlock = free): Maze {
+    const matrix = Array<Array<MazeBlock>>(size);
+    matrix.fill(Array<MazeBlock>(size));
+    matrix.forEach((row) => {
+        row.fill(default_block);
+    });
+    return {
+        width: size,
+        height: size,
+        matrix: matrix
+    };
+}
+
+/**
+ * Takes a 2d array index and converts it into a 1d index
+ * Usefull when doing operations on the Listgraph representation of the maze
+ * and need the index from the maze object that uses 2d index.
+ * 
+ * @example
+ * // Flatten the index row: 1, col: 2 of a 3x3 matrix
+ * const maze = {
+ *     width: 3,
+ *     height: 3,
+ *     matrix: [
+ *         [Free, Free, Free],
+ *         [Free, Free, Wall],
+ *         [Free, Free, Free]
+ *     ]
+ * }
+ * flatten_index(1, 3, maze)
+ * // Returns 5 which is the 6th posistion in this array
+ * // [Free, Free, Free, Free, Free, Wall, Free, Free, Free]
+ * 
+ * @param {number} row Index of the row in the 2d {Maze}
+ * @param {number} col Index of the colum in the 2d {Maze}
+ * @param {Maze} maze Maze object to refer the size of the array from
+ * @returns {number} Index of the same object in a 1d array representation
+ */
+export function flatten_index(
+    row: number,
+    col: number,
+    maze: Maze
+): number | undefined {
+    return maze.matrix.length <= row || row < 0
+        ? undefined
+        : maze.matrix[row].length <= col || col < 0
+            ? undefined
+            : (row * maze.width) + col;
+}
+
+/**
+ * Takes a index of a Array an converts it into a 2d index of a given maze
+ * Usefull when doing opperations on the Listgraph representation of the maze
+ * and need the 2d matrix index from the node that uses 1d index.
+ * 
+ * @example
+ * // deepen the index: 5 of a Array into a index of a 3x3 matrix
+ * const maze = {
+ *     width: 3,
+ *     height: 3,
+ *     matrix: [
+ *         [Free, Free, Free],
+ *         [Free, Free, Wall],
+ *         [Free, Free, Free]
+ *     ]
+ * }
+ * flatten_index(5, maze)
+ * // Returns { row: 1, col: 2 } which is the 6th posistion in this array
+ * // [Free, Free, Free, Free, Free, Wall, Free, Free, Free]
+ * 
+ * @param {number} index Index of the object in a 1d array representation
+ * @param {Maze} maze The maze to use to refer to the index 2d representation
+ * @returns { row: number; col: number } A record holding row and colum needed
+ * to reach the same object in a 2d representation
+ */
+export function deepen_index(
+    index: number,
+    maze: Maze
+): { row: number; col: number } | undefined {
+    const row = Math.floor(index / maze.width);
+    const col = index % maze.width;
+    return index < 0
+        ? undefined
+        : maze.matrix.length <= row || row < 0
+            ? undefined
+            : maze.matrix[row].length <= col || col < 0
+                ? undefined
+                : { row: row, col: col };
+}
+
+/**
+ * Converts a maze into a listgraph with edges between
+ * each non wall position of the maze
+ * 
+ * @param maze The maze to convert into a undirected listgraph
+ * @returns A undirected listgraph with edges between
+ * each non-wall node of the maze
+ */
+export function maze_to_listgraph(maze: Maze): ListGraph {
+    function has_edge(row: number, col: number): boolean {
+        return 0 <= row && row < maze.matrix.length
+            ? 0 <= col && col < maze.matrix[row].length
+                ? maze.matrix[row][col] !== wall
+                    ? true
+                    : false
+                : false
+            : false;
+    }
+    let edges: EdgeList = list();
+    maze.matrix.forEach((maze_row, row_index) => {
+        maze_row.forEach((maze_block, col_index) => {
+            if (maze_block !== wall) {
+                const source = flatten_index(row_index, col_index, maze);
+                for (let x_offset = -1; x_offset < 1; x_offset += 2) {
+                    if (has_edge(row_index, col_index + x_offset)) {
+                        const target = flatten_index(
+                            row_index,
+                            col_index + x_offset,
+                            maze
+                        );
+                        if (target !== undefined && source !== undefined) {
+                            edges = pair(
+                                pair(source, target),
+                                pair(pair(target, source), edges)
+                            );
+                        }
+                    }
+                }
+                for (let y_offset = -1; y_offset < 1; y_offset += 2) {
+                    if (has_edge(row_index + y_offset, col_index)) {
+                        const target = flatten_index(
+                            row_index + y_offset,
+                            col_index,
+                            maze
+                        );
+                        if (target !== undefined && source !== undefined) {
+                            edges = pair(
+                                pair(source, target),
+                                pair(pair(target, source), edges)
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    });
+    return lg_from_edges(maze.height * maze.width, edges);
+}

--- a/tests/maze.test.ts
+++ b/tests/maze.test.ts
@@ -1,0 +1,181 @@
+import { ListGraph } from "../src/graphs";
+import { list } from "../src/list";
+import {
+    Maze, wall,
+    free, new_maze,
+    maze_to_listgraph,
+    flatten_index,
+    deepen_index
+} from "../src/maze";
+
+
+test("Test creating a maze", () => {
+    expect(new_maze(1)).toStrictEqual(
+        {
+            width: 1,
+            height: 1,
+            matrix: [[free]]
+        } as Maze
+    );
+
+    expect(new_maze(2)).toStrictEqual(
+        {
+            width: 2,
+            height: 2,
+            matrix: [[free, free], [free, free]]
+        } as Maze
+    );
+
+    expect(new_maze(3)).toStrictEqual(
+        {
+            width: 3,
+            height: 3,
+            matrix: [
+                [free, free, free],
+                [free, free, free],
+                [free, free, free]
+            ]
+        } as Maze
+    );
+
+    expect(new_maze(3, wall)).toStrictEqual(
+        {
+            width: 3,
+            height: 3,
+            matrix: [
+                [wall, wall, wall],
+                [wall, wall, wall],
+                [wall, wall, wall]
+            ]
+        } as Maze
+    );
+});
+
+const maze_1x1_free = new_maze(1);
+const maze_1x1_walled = new_maze(1, wall);
+
+const maze_3x3_free = new_maze(3);
+const maze_3x3_walled = new_maze(3, wall);
+
+test("Test flattening a 2d index from a maze", () => {
+    expect(flatten_index(0, 0, maze_1x1_free)).toStrictEqual(0);
+    expect(flatten_index(0, 0, maze_1x1_walled)).toStrictEqual(0);
+    expect(flatten_index(0, 1, maze_1x1_free)).toStrictEqual(undefined);
+    expect(flatten_index(1, 0, maze_1x1_walled)).toStrictEqual(undefined);
+
+
+    expect(flatten_index(0, 0, maze_3x3_free)).toStrictEqual(0);
+    expect(flatten_index(0, 0, maze_3x3_walled)).toStrictEqual(0);
+
+    expect(flatten_index(0, 0, maze_3x3_walled)).toStrictEqual(0);
+    expect(flatten_index(0, 1, maze_3x3_free)).toStrictEqual(1);
+    expect(flatten_index(0, 2, maze_3x3_walled)).toStrictEqual(2);
+    expect(flatten_index(0, 3, maze_3x3_free)).toStrictEqual(undefined);
+    expect(flatten_index(1, 0, maze_3x3_walled)).toStrictEqual(3);
+    expect(flatten_index(1, 1, maze_3x3_free)).toStrictEqual(4);
+    expect(flatten_index(1, 2, maze_3x3_walled)).toStrictEqual(5);
+    expect(flatten_index(1, 3, maze_3x3_free)).toStrictEqual(undefined);
+    expect(flatten_index(2, 0, maze_3x3_walled)).toStrictEqual(6);
+    expect(flatten_index(2, 1, maze_3x3_free)).toStrictEqual(7);
+    expect(flatten_index(2, 2, maze_3x3_walled)).toStrictEqual(8);
+    expect(flatten_index(2, 3, maze_3x3_free)).toStrictEqual(undefined);
+    expect(flatten_index(3, 0, maze_3x3_walled)).toStrictEqual(undefined);
+});
+
+test("Test deepening a 1d index to a 2d index", () => {
+    expect(deepen_index(0, maze_1x1_free)).toStrictEqual(
+        { row: 0, col: 0 }
+    );
+    expect(deepen_index(0, maze_1x1_walled)).toStrictEqual(
+        { row: 0, col: 0 }
+    );
+    expect(deepen_index(1, maze_1x1_free)).toStrictEqual(
+        undefined
+    );
+    expect(deepen_index(1, maze_1x1_walled)).toStrictEqual(
+        undefined
+    );
+
+
+    expect(deepen_index(0, maze_3x3_free)).toStrictEqual(
+        { row: 0, col: 0 }
+    );
+    expect(deepen_index(0, maze_3x3_walled)).toStrictEqual(
+        { row: 0, col: 0 }
+    );
+    expect(deepen_index(0, maze_3x3_walled)).toStrictEqual(
+        { row: 0, col: 0 }
+    );
+    expect(deepen_index(1, maze_3x3_free)).toStrictEqual(
+        { row: 0, col: 1 }
+    );
+    expect(deepen_index(2, maze_3x3_walled)).toStrictEqual(
+        { row: 0, col: 2 }
+    );
+    expect(deepen_index(3, maze_3x3_walled)).toStrictEqual(
+        { row: 1, col: 0 }
+    );
+    expect(deepen_index(4, maze_3x3_free)).toStrictEqual(
+        { row: 1, col: 1 }
+    );
+    expect(deepen_index(5, maze_3x3_walled)).toStrictEqual(
+        { row: 1, col: 2 }
+    );
+    expect(deepen_index(6, maze_3x3_walled)).toStrictEqual(
+        { row: 2, col: 0 }
+    );
+    expect(deepen_index(7, maze_3x3_free)).toStrictEqual(
+        { row: 2, col: 1 }
+    );
+    expect(deepen_index(8, maze_3x3_walled)).toStrictEqual(
+        { row: 2, col: 2 }
+    );
+    expect(deepen_index(9, maze_3x3_free)).toStrictEqual(undefined);
+
+    expect(deepen_index(-1, maze_3x3_walled)).toStrictEqual(undefined);
+});
+
+
+test("Test converting a maze in to listgraph", () => {
+    expect(maze_to_listgraph(new_maze(1, free))).toStrictEqual(
+        {
+            adj: [
+                list()
+            ],
+            size: 1
+        } as ListGraph
+    );
+
+    expect(maze_to_listgraph(new_maze(1, wall))).toStrictEqual(
+        {
+            adj: [
+                list()
+            ],
+            size: 1
+        } as ListGraph
+    );
+
+    expect(maze_to_listgraph(new_maze(2, free))).toStrictEqual(
+        {
+            adj: [
+                list(1, 2),
+                list(0, 3),
+                list(0, 3),
+                list(2, 1)
+            ],
+            size: 4
+        } as ListGraph
+    );
+
+    expect(maze_to_listgraph(new_maze(2, wall))).toStrictEqual(
+        {
+            adj: [
+                list(),
+                list(),
+                list(),
+                list()
+            ],
+            size: 4
+        } as ListGraph
+    );
+});

--- a/tests/maze.test.ts
+++ b/tests/maze.test.ts
@@ -5,7 +5,11 @@ import {
     free, new_maze,
     maze_to_listgraph,
     flatten_index,
-    deepen_index
+    deepen_index,
+    MazeBlock,
+    is_path,
+    is_wall,
+    Free, Wall
 } from "../src/maze";
 
 
@@ -49,6 +53,22 @@ test("Test creating a maze", () => {
             ]
         } as Maze
     );
+});
+
+test("Test checking MazeBlock type", () => {
+    expect(is_path(true as MazeBlock)).toBeTruthy();
+    expect(is_path(false as MazeBlock)).toBeFalsy();
+    expect(is_path(true as MazeBlock)).toMatchObject<Free>;
+    expect(is_path(false as MazeBlock)).toMatchObject<Exclude<MazeBlock, Free>>;
+
+    expect(is_wall(false as MazeBlock)).toBeTruthy();
+    expect(is_wall(true as MazeBlock)).toBeFalsy();
+
+    // check if true which is Free type is a wall
+    // It is not but this method can ONLY check if it is a wall so result should
+    // be a Mazeblock that issnt a Wall
+    expect(is_path(true as MazeBlock)).toMatchObject<Exclude<MazeBlock, Wall>>;
+    expect(is_wall(false as MazeBlock)).toMatchObject<Wall>;
 });
 
 const maze_1x1_free = new_maze(1);


### PR DESCRIPTION
Added method needed to create ListGraph from our current Maze object.
This pr also contains some methods to make a refactoring of mazeblock easier to accomplish.

This will close #5 