### PR TITLE
Refactor pathfinding to streams

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -138,45 +138,34 @@ let mili_seconds = 0;
 const graph = maze_to_listgraph(maze);
 let breadth_stream = lg_breadth_first(graph, 1, 47);
 
-let in_queue = head(breadth_stream).in_queue;
-while (!is_empty(in_queue)) {
-    let pos = deepen_index(head_of_queue(in_queue), maze);
-    if (pos !== undefined) {
-        // cyan
-        textures[pos.row][pos.col].tint = 0x34ebb7;
-    }
-    in_queue = dequeue(in_queue);
-}
-
 function draw(): void {
     console.log("Drawing...");
 
-    textures = init_teture_array(maze.matrix);
+    // Draw all visited nodes
+    let visited = head(breadth_stream).visited_nodes;
+    console.log("Recived node states:", visited);
+    visited.forEach((node, index) => {
+        if (node === 1) {
+            let pos = deepen_index(index, maze);
+            if (pos !== undefined) {
+                // grå
+                textures[pos.row][pos.col].tint = 0xb0acb0;
+            }
+        }
+    });
 
-    const stream_tail = tail(breadth_stream);
-    if (!is_null(stream_tail)) {
-        breadth_stream = stream_tail();
-    }
-
-    in_queue = head(breadth_stream).in_queue;
+    // Draw all nodes pending a visit from algorithm
+    let in_queue = head(breadth_stream).in_queue;
     while (!is_empty(in_queue)) {
         let pos = deepen_index(head_of_queue(in_queue), maze);
         if (pos !== undefined) {
-            // ljusare cyan / grön
+            // ljusare cyan
             textures[pos.row][pos.col].tint = 0x34ebb7;
         }
         in_queue = dequeue(in_queue);
     }
 
-    let visited = head(breadth_stream).visited_nodes;
-    visited.forEach((node) => {
-        let pos = deepen_index(node, maze);
-        if (pos !== undefined) {
-            // grå
-            textures[pos.row][pos.col].tint = 0xb0acb0;
-        }
-    });
-
+    // Draw the path taken to reach the current node
     let current_path = head(breadth_stream).path_so_far;
     while (!is_empty(current_path)) {
         let pos = deepen_index(head_of_queue(current_path), maze);
@@ -192,6 +181,7 @@ function draw(): void {
         current_path = dequeue(current_path);
     }
 
+    // Draw the current node
     let current_node = deepen_index(
         head(breadth_stream).current_node,
         maze
@@ -199,6 +189,12 @@ function draw(): void {
     if (current_node !== undefined) {
         // lila
         textures[current_node.row][current_node.col].tint = 0xd534eb;
+    }
+
+    // Take the next step of the algorithm
+    const stream_tail = tail(breadth_stream);
+    if (!is_null(stream_tail)) {
+        breadth_stream = stream_tail();
     }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -93,7 +93,7 @@ const maze: Maze = {
 // sometinh ~2 days
 // other [optional] ~3 days
 
-function init_teture_array(
+function init_texture_array(
     maze: Maze,
     container: pixi.Container,
     width: number,
@@ -152,7 +152,7 @@ let container = new pixi.Container();
 
 // Create the record holding textures and the algorithm
 let breadth_algorithm = {
-    textures: init_teture_array(
+    textures: init_texture_array(
         maze,
         container,
         app.renderer.width / 2,
@@ -176,7 +176,7 @@ container.x = app.screen.width / 2;
 
 // Create the record holding textures and the algorithm
 let depth_algorithm = {
-    textures: init_teture_array(
+    textures: init_texture_array(
         maze,
         container,
         app.renderer.width / 2,

--- a/src/app.ts
+++ b/src/app.ts
@@ -105,7 +105,7 @@ function init_teture_array(
             result[row][col] = new pixi.Sprite(pixi.Texture.WHITE);
             switch (cell) {
             case maze_wall:
-                result[row][col].tint = 0xa0a0a0;
+                result[row][col].tint = 0x000000;
                 break;
 
             case not_visited:

--- a/src/graphs.ts
+++ b/src/graphs.ts
@@ -400,6 +400,7 @@ export function lg_breadth_first(
         }
     }
 
+    // Initialize stream with only starting node in the queue
     const stream: Stream<Result> = pair(
         {
             in_queue: next_node,
@@ -420,14 +421,4 @@ export function lg_breadth_first(
     }
 
     return stream;
-
-    // pair(värde, funktion -> pair(värde, funktion -> ... ))
-    //
-
-    // 1: vad som är i kön just nu,
-    // 2: besökt noder,
-    // 3: nuvarande node
-    // 4: nuvarande path
-    // 5: är klar?
-    // { in_queue: 1, 2, 3, 4, visited: start }
 }

--- a/src/graphs.ts
+++ b/src/graphs.ts
@@ -200,7 +200,7 @@ export function lg_depth_first(
     graph: ListGraph,
     start: Node,
     end: Node
-): Path {
+): Stream<Result> {
     // Exploration states
     const initialized = 0;
     const visited = 1;
@@ -209,7 +209,7 @@ export function lg_depth_first(
 
     // create a data type to store:
     // initialized / visited / explored state of each node.
-    const exploration_state = Array(graph.size).fill(initialized);
+    const exploration_state = Array<number>(graph.size).fill(initialized);
 
     // create a data type to store the path to the given node
     // (Path from `start` node)
@@ -237,14 +237,27 @@ export function lg_depth_first(
 
     // Stepwise progression of dfs algorithm,
     // can easily be made into a stream call.
-    function lg_depth_first_step(): boolean {
+    function lg_depth_first_step(): Result {
         if (!is_stack_empty(next_node)) {
             const node = stack_head(next_node);
             next_node = pop(next_node);
             if (node === end) {
-                // TODO: return result
-                return false;
+                return {
+                    in_queue: next_node,
+                    visited_nodes: exploration_state,
+                    current_node: node,
+                    path_so_far: path_to_node[node],
+                    is_done: true
+                };
             }
+
+            const non_visited = filter(
+                (edge_endpoint) => {
+                    return exploration_state[edge_endpoint] === initialized;
+                },
+                graph.adj[node]
+            );
+
             for_each(
                 (unvisted_node) => {
                     path_to_node[unvisted_node] = lg_depth_first_visit(
@@ -252,25 +265,54 @@ export function lg_depth_first(
                         path_to_node[node]
                     );
                 },
-                filter((edge_endpoint) => {
-                    return exploration_state[edge_endpoint] === initialized;
-                }, graph.adj[node])
+                non_visited
             );
-            return true;
+
+            const visited_nodes_this_loop = Array<Node>();
+            for_each((node) => visited_nodes_this_loop.push(node), non_visited);
+
+            return {
+                in_queue: next_node,
+                visited_nodes: exploration_state,
+                current_node: node,
+                path_so_far: path_to_node[node],
+                is_done: false
+            };
         } else {
-            return false;
+            return {
+                in_queue: next_node,
+                visited_nodes: exploration_state,
+                current_node: -1,
+                path_so_far: path_to_node[end],
+                is_done: true
+            };
         }
     }
 
-    // runs lg_depth_first_step untill we have either visited all nodes
-    // or we are at the goal.
-    let running = lg_depth_first_step();
-    while (running) {
-        // run lg_depth_first_step untill we are at the end.
-        running = lg_depth_first_step();
+    // Initialize stream with only starting node in the stack
+    const stream: Stream<Result> = pair(
+        {
+            in_queue: next_node,
+            visited_nodes: Array<Node>(),
+            current_node: -1,
+            path_so_far: null,
+            is_done: false
+        },
+        () => data_stream()
+    );
+
+    // runs a single step of the algorithm and returns the state.
+    // paired with a refrence toi this function to get the next state.
+    // lazy evaluation
+    function data_stream(): Stream<Result> {
+        const result = lg_depth_first_step();
+        return pair(
+            result,
+            result.is_done ? null : data_stream
+        );
     }
 
-    return path_to_node[end];
+    return stream;
 }
 
 /**

--- a/src/graphs.ts
+++ b/src/graphs.ts
@@ -293,16 +293,20 @@ export function lg_depth_first(
  *     size: 8
  * };
  * lg_breadth_first(listgraph, 0, 6);
- * // results in Queue(0, 3, 6)
+ * // results in Queue(0, 3, 6) after evaluating the stream
  * // meaing 0 -> 3 -> 6
  * ```
  * 
  * @param graph the unweighted listgraph to perform the breadth first search on.
  * @param start the starting node to search from
  * @param end the ending node you want to reach
- * @returns A Path type conatining either
- * a Queue<Node> of nodes to visit in order to reach the end 
- * or null if no path was found from start to end.
+ * @returns A Stream<Result> information regarding
+ * the algorithms path thru the graph. It also contains
+ * the path so far put this path can lead to a postion far away from the
+ * end point. to get a path to the end you need to evaluate the stream
+ * utill the is_done porpertie has evaluated to true.
+ * when is_done is set to true you will have a path from start to end
+ * if such a path exists.
  */
 export function lg_breadth_first(
     graph: ListGraph,
@@ -317,7 +321,7 @@ export function lg_breadth_first(
 
     // create a data type to store:
     // initialized / visited / explored state of each node.
-    const exploration_state = Array(graph.size).fill(initialized);
+    const exploration_state = Array<number>(graph.size).fill(initialized);
 
     // create a data type to store the path to the given node
     // (Path from `start` node)
@@ -351,7 +355,7 @@ export function lg_breadth_first(
             if (node === end) {
                 return {
                     in_queue: next_node,
-                    visited_nodes: Array<Node>(),
+                    visited_nodes: exploration_state,
                     current_node: node,
                     path_so_far: path_to_node[node],
                     is_done: true
@@ -380,7 +384,7 @@ export function lg_breadth_first(
 
             return {
                 in_queue: next_node,
-                visited_nodes: visited_nodes_this_loop,
+                visited_nodes: exploration_state,
                 current_node: node,
                 path_so_far: path_to_node[node],
                 is_done: false
@@ -388,7 +392,7 @@ export function lg_breadth_first(
         } else {
             return {
                 in_queue: next_node,
-                visited_nodes: [],
+                visited_nodes: exploration_state,
                 current_node: -1,
                 path_so_far: path_to_node[end],
                 is_done: true

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,5 +1,21 @@
 import { Queue } from "./queue_immutable";
 import { Node } from "./graphs";
+import { Pair } from "./list";
 
 export type Path = Queue<Node> | null;
-export type Result = Path;
+
+// 1: vad som är i kön just nu,
+// 2: besökt noder,
+// 3: nuvarande node
+// 4: nuvarande path
+// 5: är klar?
+// { in_queue: 1, 2, 3, 4, visited: start }
+export type Result = {
+    in_queue: Queue<Node>;
+    visited_nodes: Array<Node>;
+    current_node: Node;
+    path_so_far: Path;
+    is_done: boolean;
+};
+
+export type Stream<T> = Pair<T, (() => Stream<T>) | null>;

--- a/src/path.ts
+++ b/src/path.ts
@@ -11,11 +11,11 @@ export type Path = Queue<Node> | null;
 // 5: är klar?
 // { in_queue: 1, 2, 3, 4, visited: start }
 export type Result = {
-    in_queue: Queue<Node>;
-    visited_nodes: Array<Node>;
-    current_node: Node;
-    path_so_far: Path;
-    is_done: boolean;
+    readonly in_queue: Queue<Node>;
+    readonly visited_nodes: Array<Node>;
+    readonly current_node: Node;
+    readonly path_so_far: Path;
+    readonly is_done: boolean;
 };
 
 export type Stream<T> = Pair<T, (() => Stream<T>) | null>;

--- a/tests/graphs.test.ts
+++ b/tests/graphs.test.ts
@@ -5,7 +5,8 @@ import {
     lg_from_edges, lg_new, lg_transpose,
     lg_depth_first, lg_breadth_first
 } from "../src/graphs";
-import { list } from "../src/list";
+import { head, is_null, list, tail } from "../src/list";
+import { Result, Stream } from "../src/path";
 import { Queue } from "../src/queue_immutable";
 
 
@@ -474,8 +475,21 @@ const listgraph: ListGraph = {
     size: 8
 };
 
+function eval_breadth_first_stream(stream: Stream<Result>): Result {
+    let return_value = stream;
+    while (!head(return_value).is_done) {
+        let stream_tail = tail(return_value);
+        if (!is_null(stream_tail)) {
+            return_value = stream_tail();
+        } else {
+            return head(return_value);
+        }
+    }
+    return head(return_value);
+}
+
 test("test listgraph breadth first search", () => {
-    expect(
+    let result: Result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -488,11 +502,15 @@ test("test listgraph breadth first search", () => {
             a,
             b
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, null]] as Queue<number>
     );
 
-    expect(
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -506,11 +524,15 @@ test("test listgraph breadth first search", () => {
             a,
             c
         )
+    );
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [c, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -524,11 +546,15 @@ test("test listgraph breadth first search", () => {
             b,
             c
         )
+    );
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [b, [c, null]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -542,11 +568,16 @@ test("test listgraph breadth first search", () => {
             c,
             b
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         null
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -560,11 +591,16 @@ test("test listgraph breadth first search", () => {
             c,
             b
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [c, [b, null]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -580,11 +616,16 @@ test("test listgraph breadth first search", () => {
             a,
             e
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [c, [e, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -601,11 +642,16 @@ test("test listgraph breadth first search", () => {
             a,
             f
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [c, [f, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(
             {
                 adj:
@@ -622,30 +668,54 @@ test("test listgraph breadth first search", () => {
             a,
             f
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [d, [f, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(listgraph, a, g)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [d, [g, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(listgraph, a, h)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [f, [h, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(listgraph, a, c)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [c, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_breadth_first_stream(
         lg_breadth_first(listgraph, a, e)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [d, [e, null]]] as Queue<number>
     );

--- a/tests/graphs.test.ts
+++ b/tests/graphs.test.ts
@@ -475,7 +475,7 @@ const listgraph: ListGraph = {
     size: 8
 };
 
-function eval_breadth_first_stream(stream: Stream<Result>): Result {
+function eval_stream(stream: Stream<Result>): Result {
     let return_value = stream;
     while (!head(return_value).is_done) {
         let stream_tail = tail(return_value);
@@ -489,7 +489,7 @@ function eval_breadth_first_stream(stream: Stream<Result>): Result {
 }
 
 test("test listgraph breadth first search", () => {
-    let result: Result = eval_breadth_first_stream(
+    let result: Result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -510,7 +510,7 @@ test("test listgraph breadth first search", () => {
         [a, [b, null]] as Queue<number>
     );
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -532,7 +532,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -554,7 +554,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -577,7 +577,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -600,7 +600,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -625,7 +625,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -651,7 +651,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(
             {
                 adj:
@@ -677,7 +677,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(listgraph, a, g)
     );
 
@@ -688,7 +688,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(listgraph, a, h)
     );
 
@@ -699,7 +699,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(listgraph, a, c)
     );
 
@@ -710,7 +710,7 @@ test("test listgraph breadth first search", () => {
     );
 
 
-    result = eval_breadth_first_stream(
+    result = eval_stream(
         lg_breadth_first(listgraph, a, e)
     );
 
@@ -723,7 +723,7 @@ test("test listgraph breadth first search", () => {
 
 
 test("test listgraph depth first search", () => {
-    expect(
+    let result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -736,11 +736,15 @@ test("test listgraph depth first search", () => {
             a,
             b
         )
+    );
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, null]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -754,11 +758,15 @@ test("test listgraph depth first search", () => {
             a,
             c
         )
+    );
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [c, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -772,11 +780,16 @@ test("test listgraph depth first search", () => {
             b,
             c
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [b, [c, null]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -790,11 +803,16 @@ test("test listgraph depth first search", () => {
             c,
             b
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         null
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -808,11 +826,16 @@ test("test listgraph depth first search", () => {
             c,
             b
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [c, [b, null]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -828,11 +851,16 @@ test("test listgraph depth first search", () => {
             a,
             e
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [d, [e, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -849,11 +877,16 @@ test("test listgraph depth first search", () => {
             a,
             f
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [d, [e, [f, null]]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -870,11 +903,16 @@ test("test listgraph depth first search", () => {
             a,
             f
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [d, [f, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -891,11 +929,16 @@ test("test listgraph depth first search", () => {
             a,
             c
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [f, [e, [d, [c, null]]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(
             {
                 adj:
@@ -912,30 +955,54 @@ test("test listgraph depth first search", () => {
             a,
             c
         )
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [c, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(listgraph, a, g)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [d, [g, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(listgraph, a, h)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [b, [f, [h, null]]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(listgraph, a, c)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [d, [c, null]]] as Queue<number>
     );
 
-    expect(
+
+    result = eval_stream(
         lg_depth_first(listgraph, a, e)
+    );
+
+    expect(
+        result.path_so_far
     ).toStrictEqual(
         [a, [d, [e, null]]] as Queue<number>
     );


### PR DESCRIPTION
This is the pull request to get code from feb 21 into dev.
Updated app to now show a actual algorithm instead of random movement.
Updated app to show algorithm step by step.
Updated app to show both dfs and bfs side by side (with their worst possible situation).

Updated Result to type to store relevant information
Updated depth_first_serach to give us a Stream<Result>
Updated breadth_first_serach to give us a Stream<Result>

Current solution passes entire state array of the maze from the algorithm to help coloring in the gray squares.
Would be cool if we could revert to only sending what square was visited on current loop and then just add that draw recolors all (non white && non black) to gray as a base and then recolors depending on result object.